### PR TITLE
Update README.md - python-dev to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
     ```
     sudo apt-get update
     # General dependencies
-    sudo apt-get install -y python-dev pkg-config
+    sudo apt-get install -y python3 pkg-config
 
     # Library components
     sudo apt-get install libavformat-dev libavcodec-dev libavdevice-dev \


### PR DESCRIPTION
```
ubuntu@ubuntu:~$ sudo apt-get install -y python-dev pkg-config
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python2-dev python2 python-dev-is-python3

E: Package 'python-dev' has no installation candidate
```